### PR TITLE
Reduce memory consumption dumping large tables

### DIFF
--- a/dump.go
+++ b/dump.go
@@ -130,7 +130,7 @@ func (s3d *sqlite3dumper) dumpDB(db *sql.DB, out io.Writer) (err error) {
 
 		// Build the insert statement for each row of the current table
 		schema.Name = strings.Replace(schema.Name, `"`, `""`, -1)
-		err = s3d.getTableRows(out, db, schema.Name)
+		err = s3d.writeInsStmtsForTableRows(out, db, schema.Name)
 		if err != nil {
 			return err
 		}
@@ -174,7 +174,7 @@ func (s3d *sqlite3dumper) writeDropStatements(w io.Writer, schemas []schema) (er
 	return nil
 }
 
-func (s3d *sqlite3dumper) getTableRows(w io.Writer, db *sql.DB, tableName string) (err error) {
+func (s3d *sqlite3dumper) writeInsStmtsForTableRows(w io.Writer, db *sql.DB, tableName string) (err error) {
 	// first get the column names
 	columnNames, err := s3d.pragmaTableInfo(db, tableName)
 	if err != nil {

--- a/dump.go
+++ b/dump.go
@@ -130,13 +130,9 @@ func (s3d *sqlite3dumper) dumpDB(db *sql.DB, out io.Writer) (err error) {
 
 		// Build the insert statement for each row of the current table
 		schema.Name = strings.Replace(schema.Name, `"`, `""`, -1)
-		var inserts []string
-		inserts, err = s3d.getTableRows(db, schema.Name)
+		err = s3d.getTableRows(out, db, schema.Name)
 		if err != nil {
 			return err
-		}
-		for _, insert := range inserts {
-			out.Write([]byte(fmt.Sprintf("%s;\n", insert)))
 		}
 	}
 
@@ -178,7 +174,7 @@ func (s3d *sqlite3dumper) writeDropStatements(w io.Writer, schemas []schema) (er
 	return nil
 }
 
-func (s3d *sqlite3dumper) getTableRows(db *sql.DB, tableName string) (inserts []string, err error) {
+func (s3d *sqlite3dumper) getTableRows(w io.Writer, db *sql.DB, tableName string) (err error) {
 	// first get the column names
 	columnNames, err := s3d.pragmaTableInfo(db, tableName)
 	if err != nil {
@@ -220,17 +216,18 @@ func (s3d *sqlite3dumper) getTableRows(db *sql.DB, tableName string) (inserts []
 	}
 	defer rows.Close()
 
-	inserts = []string{}
 	for rows.Next() {
 		var insert string
 		err = rows.Scan(&insert)
 		if err != nil {
 			return
 		}
-		inserts = append(inserts, insert)
+		_, err = w.Write([]byte(fmt.Sprintf("%s;\n", insert)))
+		if err != nil {
+			return
+		}
 	}
-	err = rows.Err()
-	return
+	return rows.Err()
 }
 
 func (s3d *sqlite3dumper) pragmaTableInfo(db *sql.DB, tableName string) (columnNames []string, err error) {

--- a/dump_test.go
+++ b/dump_test.go
@@ -6,11 +6,18 @@ import (
 	"database/sql"
 	"io/ioutil"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func assertEqualIgnoreLineSeparators(t *testing.T, expected []byte, actual []byte) {
+	expectedStr := strings.ReplaceAll(string(expected), "\r\n", "\n")
+	actualStr := strings.ReplaceAll(string(actual), "\r\n", "\n")
+	assert.Equal(t, expectedStr, actualStr)
+}
 
 func TestCars(t *testing.T) {
 	var b bytes.Buffer
@@ -19,7 +26,7 @@ func TestCars(t *testing.T) {
 	assert.Nil(t, err)
 	out.Flush()
 	pythonOutput, _ := ioutil.ReadFile("testdata/python.sql")
-	assert.Equal(t, pythonOutput, b.Bytes())
+	assertEqualIgnoreLineSeparators(t, pythonOutput, b.Bytes())
 	ioutil.WriteFile("out.sql", b.Bytes(), 0644)
 }
 
@@ -36,7 +43,7 @@ func TestMigrate(t *testing.T) {
 
 	out.Flush()
 	pythonOutput, _ := ioutil.ReadFile("testdata/migrate.sql")
-	assert.Equal(t, pythonOutput, b.Bytes())
+	assertEqualIgnoreLineSeparators(t, pythonOutput, b.Bytes())
 }
 
 func TestDump(t *testing.T) {
@@ -79,7 +86,7 @@ func TestDump(t *testing.T) {
 			out.Flush()
 
 			got := b.Bytes()
-			assert.Equal(t, expect, got)
+			assertEqualIgnoreLineSeparators(t, expect, got)
 		})
 	}
 }


### PR DESCRIPTION
collecting all insert statements for tables with many rows in a []string instead of writing them out directly will consume an unnecessary huge amount of memory while dumping a database

May I propose this little change to optimize memory consumption.

PS: To make the tests run on my windows system, I adapted the assertion on []byte equality to ignore windows like line break.